### PR TITLE
Improve error handling in shadowx driver process hiding routine

### DIFF
--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -1,3 +1,4 @@
+[workspace]
 [package]
 name = "shadow"
 version = "0.1.0"

--- a/driver/shadow.inx
+++ b/driver/shadow.inx
@@ -5,7 +5,7 @@
 [Version]
 Signature   = "$WINDOWS NT$"
 Class       = System ; TODO: specify appropriate Class
-ClassGuid   = {E7C2B7F0-3F3D-4EC8-B98A-123456789ABC} ; TODO: specify appropriate ClassGuid
+ClassGuid   = {4d36e97d-e325-11ce-bfc1-08002be10318} ; TODO: specify appropriate ClassGuid
 Provider    = %ManufacturerName%
 CatalogFile = shadow.cat
 DriverVer   = ; TODO: set DriverVer in stampinf property pages
@@ -23,9 +23,6 @@ shadow.sys  = 1,,
 ;*****************************************
 ; Install Section
 ;*****************************************
-[DefaultInstall]
-CopyFiles = File_Copy
-AddService = shadow, 0x00000002, shadow_Service_Inst
 
 [Manufacturer]
 %ManufacturerName% = Standard,NT$ARCH$.10.0...16299 ; %13% support introduced in build 16299

--- a/driver/shadow.inx
+++ b/driver/shadow.inx
@@ -1,14 +1,12 @@
-;
 ; shadow.inf
-;
 
 [Version]
-Signature   = "$WINDOWS NT$"
-Class       = System ; TODO: specify appropriate Class
-ClassGuid   = {4d36e97d-e325-11ce-bfc1-08002be10318} ; TODO: specify appropriate ClassGuid
-Provider    = %ManufacturerName%
+Signature = "$WINDOWS NT$"
+Class = System
+ClassGuid = {4d36e97d-e325-11ce-bfc1-08002be10318}
+Provider = %ManufacturerName%
 CatalogFile = shadow.cat
-DriverVer   = ; TODO: set DriverVer in stampinf property pages
+DriverVer = 03/04/2025,16.12.53.325
 PnpLockdown = 1
 
 [DestinationDirs]
@@ -18,29 +16,15 @@ DefaultDestDir = 13
 1 = %DiskName%,,,""
 
 [SourceDisksFiles]
-shadow.sys  = 1,,
+shadow.sys = 1,,
 
-;*****************************************
-; Install Section
-;*****************************************
-
-[Manufacturer]
-%ManufacturerName% = Standard,NT$ARCH$.10.0...16299 ; %13% support introduced in build 16299
-
-[Standard.NT$ARCH$.10.0...16299]
-%shadow.DeviceDesc% = shadow_Device, Root\shadow ; TODO: edit hw-id
-
-[shadow_Device.NT]
+[DefaultInstall.NTamd64]
 CopyFiles = File_Copy
+AddService = shadow, 0x00000002, shadow_Service_Inst
 
 [File_Copy]
 shadow.sys
 
-;-------------- Service installation
-[shadow_Device.NT.Services]
-AddService = shadow,%SPSVCINST_ASSOCSERVICE%, shadow_Service_Inst
-
-; -------------- shadow driver install sections
 [shadow_Service_Inst]
 DisplayName    = %shadow.SVCDESC%
 ServiceType    = 1               ; SERVICE_KERNEL_DRIVER
@@ -48,15 +32,7 @@ StartType      = 3               ; SERVICE_DEMAND_START
 ErrorControl   = 1               ; SERVICE_ERROR_NORMAL
 ServiceBinary  = %13%\shadow.sys
 
-[shadow_Device.NT.Wdf]
-KmdfService = shadow, shadow_wdfsect
-
-[shadow_wdfsect]
-KmdfLibraryVersion = $KMDFVERSION$
-
 [Strings]
-SPSVCINST_ASSOCSERVICE = 0x00000002
-ManufacturerName = "<Your manufacturer name>" ;TODO: Replace with your manufacturer name
-DiskName = "shadow Installation Disk"
-shadow.DeviceDesc = "shadow Device"
-shadow.SVCDESC = "shadow Service"
+ManufacturerName = "test"
+DiskName         = "shadow Installation Disk"
+shadow.SVCDESC    = "shadow Service"

--- a/driver/shadow.inx
+++ b/driver/shadow.inx
@@ -5,7 +5,7 @@
 [Version]
 Signature   = "$WINDOWS NT$"
 Class       = System ; TODO: specify appropriate Class
-ClassGuid   = {4d36e97d-e325-11ce-bfc1-08002be10318} ; TODO: specify appropriate ClassGuid
+ClassGuid   = {E7C2B7F0-3F3D-4EC8-B98A-123456789ABC} ; TODO: specify appropriate ClassGuid
 Provider    = %ManufacturerName%
 CatalogFile = shadow.cat
 DriverVer   = ; TODO: set DriverVer in stampinf property pages
@@ -23,6 +23,9 @@ shadow.sys  = 1,,
 ;*****************************************
 ; Install Section
 ;*****************************************
+[DefaultInstall]
+CopyFiles = File_Copy
+AddService = shadow, 0x00000002, shadow_Service_Inst
 
 [Manufacturer]
 %ManufacturerName% = Standard,NT$ARCH$.10.0...16299 ; %13% support introduced in build 16299

--- a/install-driver.ps1
+++ b/install-driver.ps1
@@ -1,0 +1,44 @@
+# Ensure the script is running with administrative privileges.
+if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator"))
+{
+    Write-Error "This script must be run as Administrator."
+    exit 1
+}
+
+# Set the path to your INF file (update this path as needed)
+$InfPath = "C:\path\to\shadow.inf"
+$InfFullPath = Resolve-Path $InfPath
+
+Write-Output "Installing INF from: $InfFullPath"
+
+# Construct and run the rundll32 command to install the INF using the DefaultInstall.NTamd64 section
+$rundllCmd = "rundll32.exe setupapi,InstallHinfSection DefaultInstall.NTamd64 132 `"$InfFullPath`""
+Write-Output "Executing: $rundllCmd"
+Invoke-Expression $rundllCmd
+
+# Pause briefly to allow the INF installation to complete
+Start-Sleep -Seconds 5
+
+# Search for the driver file (shadow.sys) in the DriverStore\FileRepository
+$DriverStorePath = "C:\Windows\System32\DriverStore\FileRepository"
+$shadowSys = Get-ChildItem -Path $DriverStorePath -Recurse -Filter "shadow.sys" -ErrorAction SilentlyContinue | Select-Object -First 1
+
+if ($null -eq $shadowSys) {
+    Write-Error "shadow.sys not found in DriverStore\FileRepository."
+    exit 1
+}
+
+$DriverFilePath = $shadowSys.FullName
+Write-Output "Driver file found at: $DriverFilePath"
+
+# Create the service using sc.exe
+$ServiceName = "shadow"
+# Wrap the path in quotes (note the backticks for proper escaping in the command line)
+$binPath = "`"$DriverFilePath`""
+$scCommand = "sc.exe create $ServiceName type= kernel binPath= $binPath start= demand"
+Write-Output "Executing: $scCommand"
+Invoke-Expression $scCommand
+
+# Query the service to verify it was created
+Write-Output "Querying service $ServiceName:"
+sc.exe query $ServiceName

--- a/install-driver.ps1
+++ b/install-driver.ps1
@@ -40,5 +40,5 @@ Write-Output "Executing: $scCommand"
 Invoke-Expression $scCommand
 
 # Query the service to verify it was created
-Write-Output "Querying service $ServiceName:"
+Write-Output "Querying service $ServiceName"
 sc.exe query $ServiceName

--- a/install-driver.txt
+++ b/install-driver.txt
@@ -1,1 +1,1 @@
-rundll32.exe setupapi,InstallHinfSection DefaultInstall 132 C:\path\to\shadow.inf
+rundll32.exe setupapi,InstallHinfSection DefaultInstall.NTamd64 132 C:\path\to\shadow.inf

--- a/install-driver.txt
+++ b/install-driver.txt
@@ -1,0 +1,1 @@
+rundll32.exe setupapi,InstallHinfSection DefaultInstall 132 C:\path\to\shadow.inf

--- a/install-driver.txt
+++ b/install-driver.txt
@@ -1,1 +1,0 @@
-rundll32.exe setupapi,InstallHinfSection DefaultInstall.NTamd64 132 C:\path\to\shadow.inf

--- a/shadowx/Cargo.toml
+++ b/shadowx/Cargo.toml
@@ -16,6 +16,7 @@ wdk-sys = "^0.3.0"
 wdk-alloc = "^0.3.0"
 spin = "0.9.8"
 obfstr = "0.4.4"
+log = "0.4.22"
 bitfield = "0.17.0"
 ntapi = { version = "0.4.1", default-features = false }
 thiserror = { version = "2.0.10", default-features = false }

--- a/shadowx/src/error.rs
+++ b/shadowx/src/error.rs
@@ -145,6 +145,10 @@ pub enum ShadowError {
     /// This occurs when the system fails to remove a callback that was previously registered.
     #[error("Error removing a callback")]
     RemoveFailureCallback,
+    /// Represents an error when the process's active list entry is invalid,
+    /// such as when both the forward and backward pointers are null.
+    #[error("Invalid list entry encountered")]
+    InvalidListEntry,
 
     /// Error indicating that a failure occurred while restoring a callback.
     ///


### PR DESCRIPTION
Improved error handling from process hiding routine (linked list null pointers were not validated before write operation was attempted which to system service exception BSOD). Added empty [workspace] tag to driver. Refactored inf generation and installation (old inf failed validation and installation when it was attempted - "unable to find matching device"). Inf was refactored for default install, and the install-driver.ps1 script was added to automatically invoke rundll32 to perform a default install of the driver, and to create the associated service from the filerepository directory that the kernel driver is copied to during the inf install. Added error for invalid list entry.